### PR TITLE
Extend destroyTimer to 2 minutes

### DIFF
--- a/server.js
+++ b/server.js
@@ -100,7 +100,7 @@ io.on("connection", (socket) => {
         () => {
           destroyTimer({ roomName, timerStore });
         },
-        10000 // give the users 10 seconds to rejoin
+        120000 // give the users 2 minutes to rejoin
       );
     }
 


### PR DESCRIPTION
## Description of the change

### Fixes # (issue that will be closed by this PR)
- Issue CommunityFocus/CommunityFocus#25

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes made
- Update setTimeout delay time to 2 minutes

### Screenshots/ Screenshare
- Tested by creating a room, exiting the room and reentering the room after the timer passed 1 minute.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I updated the comment to match the functionality
- [x] My changes generate no new warnings or errors