### PR TITLE
Run timer on client

### DIFF
--- a/helpers/startTimer.js
+++ b/helpers/startTimer.js
@@ -9,21 +9,25 @@ function startCountdown({ roomName, durationInSeconds, io, timerStore }) {
   // emit a message to the room to let everyone know the countdown has started
   io.to(roomName).emit("timerStarted", durationInSeconds);
 
+  let remainingTime = (timerStore[roomName].secondsRemaining =
+    durationInSeconds);
   // set up the timer instance
-  let remainingTime = durationInSeconds;
   timerStore[roomName].timer = setInterval(() => {
     // if the timer has reached zero, clear the interval and emit a message to the room
     if (remainingTime <= 0) {
       clearInterval(timerStore[roomName].timer);
+
+      // update the remainingTime in the timerStore
+      timerStore[roomName].secondsRemaining = 0;
       io.to(roomName).emit("timerEnded");
     } else {
       // decrement the remaining time
       remainingTime--;
 
-      // emit the updated remaining time to the room
-      io.to(roomName).emit("timerUpdated", remainingTime);
+      // update the remainingTime in the timerStore
+      timerStore[roomName].secondsRemaining = remainingTime;
     }
-    console.log({ roomName, remainingTime });
+    // console.log({ roomName, remainingTime, timerSecondsRemaining: timerStore[roomName].secondsRemaining });
   }, 1000);
 }
 

--- a/helpers/startTimer.js
+++ b/helpers/startTimer.js
@@ -29,6 +29,10 @@ function startCountdown({ roomName, durationInSeconds, io, timerStore }) {
     }
     // console.log({ roomName, remainingTime, timerSecondsRemaining: timerStore[roomName].secondsRemaining });
   }, 1000);
+  io.to(roomName).emit("timerResponse", {
+    secondsRemaining: remainingTime,
+    isPaused: false,
+  });
 }
 
 module.exports = { startCountdown };

--- a/helpers/timerRequest.js
+++ b/helpers/timerRequest.js
@@ -1,0 +1,25 @@
+const timerRequest = ({ io, timerStore, roomName, socket }) => {
+  let currentSecondsRemaining = timerStore[roomName].secondsRemaining;
+  let currentIsPaused = timerStore[roomName].isPaused;
+  let isEventEmitted = false;
+
+  while (
+    timerStore[roomName].secondsRemaining <= currentSecondsRemaining &&
+    !isEventEmitted
+  ) {
+    console.log("Emitting timerResponse",{ roomName, currentSecondsRemaining, currentIsPaused, timerSecondsRemaining: timerStore[roomName].secondsRemaining });
+
+    if (currentSecondsRemaining <= timerStore[roomName].secondsRemaining) {
+      currentSecondsRemaining = timerStore[roomName].secondsRemaining;
+      currentIsPaused = timerStore[roomName].isPaused;
+      socket.emit("timerResponse", {
+        secondsRemaining: currentSecondsRemaining,
+        isPaused: currentIsPaused,
+      });
+      isEventEmitted = true;
+      break;
+    }
+  }
+};
+
+module.exports = { timerRequest };


### PR DESCRIPTION
## Description
Move timer logic on to the frontend instead of solely on the backend.

Previous logic: There was a `setInterval` on the server for any given room that emitted the `timestamp` every second to connected clients. The client listened for the `timestamp` event and displayed it on the user using a state.
 
Problem with the old logic: Loss of internet/slow internet would cause the timer to jump/lose connection and/or not ring/notify when it hits 00:00.

New logic: the `setInterval` on the server still runs (source of truth) but does not emit the `timestamp` event. Instead, the client requests the `timerRequest` event whenever `join`, or `startCountdown` events occur. This is listened to on the server and is responded with a `timerResponse`, which the client uses to update the `timestamp` state