### PR TITLE
Add Pausing/Unpausing timer functionality #17

### DIFF
--- a/common/types/socket/types.ts
+++ b/common/types/socket/types.ts
@@ -10,7 +10,7 @@ export interface EmitTimerRequestArgs {
 }
 
 export interface EmitTPauseArgs {
-  roomName: string;
+	roomName: string;
 }
 
 export interface EmitTimerResponseArgs {
@@ -28,8 +28,8 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
 	startCountdown: (data: EmitStartCountdownArgs) => void;
 	join: (roomName: string) => void;
-  timerRequest: (data: EmitTimerRequestArgs) => void;
-  pauseCountdown: (data: EmitTPauseArgs) => void;
+	timerRequest: (data: EmitTimerRequestArgs) => void;
+	pauseCountdown: (data: EmitTPauseArgs) => void;
 }
 
 // io.on

--- a/common/types/socket/types.ts
+++ b/common/types/socket/types.ts
@@ -30,7 +30,6 @@ export interface ClientToServerEvents {
 	join: (roomName: string) => void;
   timerRequest: (data: EmitTimerRequestArgs) => void;
   pauseCountdown: (data: EmitTPauseArgs) => void;
-  // disconnect: () => void;
 }
 
 // io.on

--- a/common/types/socket/types.ts
+++ b/common/types/socket/types.ts
@@ -9,6 +9,10 @@ export interface EmitTimerRequestArgs {
 	roomName: string;
 }
 
+export interface EmitTPauseArgs {
+  roomName: string;
+}
+
 export interface EmitTimerResponseArgs {
 	secondsRemaining: number;
 	isPaused: boolean;
@@ -23,11 +27,10 @@ export interface ServerToClientEvents {
 // socket.on
 export interface ClientToServerEvents {
 	startCountdown: (data: EmitStartCountdownArgs) => void;
-	timerRequest: (data: EmitTimerRequestArgs) => void;
-	pauseCountdown: () => void;
-	unpauseCountdown: () => void;
 	join: (roomName: string) => void;
-	// disconnect: () => void;
+  timerRequest: (data: EmitTimerRequestArgs) => void;
+  pauseCountdown: (data: EmitTPauseArgs) => void;
+  // disconnect: () => void;
 }
 
 // io.on

--- a/helpers/startTimer.test.ts
+++ b/helpers/startTimer.test.ts
@@ -22,14 +22,14 @@ describe("startCountdown", () => {
 				emit: jest.fn(),
 			};
 
-      mockTimer = jest.fn().mockImplementation();
-      timerStore = {
-        [roomName]: {
-          timer: mockTimer,
-          isPaused: false,
-        },
-      };
-    });
+			mockTimer = jest.fn().mockImplementation();
+			timerStore = {
+				[roomName]: {
+					timer: mockTimer,
+					isPaused: false,
+				},
+			};
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -254,56 +254,58 @@ describe("startCountdown", () => {
 						jest.advanceTimersByTime(1000);
 						jest.advanceTimersByTime(1000);
 
-            expect(io.emit).toHaveBeenCalledTimes(1);
-            expect(io.emit).toHaveBeenCalledWith("timerResponse", {
-              secondsRemaining: 10,
-              isPaused: false,
-            });
-          });
-        });
-      });
+						expect(io.emit).toHaveBeenCalledTimes(1);
+						expect(io.emit).toHaveBeenCalledWith("timerResponse", {
+							secondsRemaining: 10,
+							isPaused: false,
+						});
+					});
+				});
+			});
 
-      describe("when the timer is paused", () => {
-        describe("when the timer is paused before the timer is started", () => {
-          it("should not decrement the secondsRemaining", () => {
-            timerStore[roomName].isPaused = true;
-            startCountdown({
-              roomName,
-              durationInSeconds: 10,
-              io: io as any,
-              timerStore: timerStore as any,
-            });
-            jest.advanceTimersByTime(1000);
-            expect(timerStore[roomName].secondsRemaining).toEqual(10);
-          });
+			describe("when the timer is paused", () => {
+				describe("when the timer is paused before the timer is started", () => {
+					it("should not decrement the secondsRemaining", () => {
+						timerStore[roomName].isPaused = true;
+						startCountdown({
+							roomName,
+							durationInSeconds: 10,
+							io: io as any,
+							timerStore: timerStore as any,
+						});
+						jest.advanceTimersByTime(1000);
+						expect(timerStore[roomName].secondsRemaining).toEqual(
+							10
+						);
+					});
 
-          it("should not clear the timer", () => {
-            timerStore[roomName].isPaused = true;
-            startCountdown({
-              roomName,
-              durationInSeconds: 10,
-              io: io as any,
-              timerStore: timerStore as any,
-            });
-            jest.advanceTimersByTime(1000);
-            // should only be called once when the timer is started
-            expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
-          });
-        });
-      });
-      it("should emit a timerResponse event to the room", () => {
-        startCountdown({
-          roomName,
-          durationInSeconds: 10,
-          io: io as any,
-          timerStore: timerStore as any,
-        });
-        expect(io.to).toHaveBeenCalledWith(roomName);
-        expect(io.emit).toHaveBeenCalledWith("timerResponse", {
-          secondsRemaining: 10,
-          isPaused: false,
-        });
-      });
-    });
-  });
+					it("should not clear the timer", () => {
+						timerStore[roomName].isPaused = true;
+						startCountdown({
+							roomName,
+							durationInSeconds: 10,
+							io: io as any,
+							timerStore: timerStore as any,
+						});
+						jest.advanceTimersByTime(1000);
+						// should only be called once when the timer is started
+						expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+					});
+				});
+			});
+			it("should emit a timerResponse event to the room", () => {
+				startCountdown({
+					roomName,
+					durationInSeconds: 10,
+					io: io as any,
+					timerStore: timerStore as any,
+				});
+				expect(io.to).toHaveBeenCalledWith(roomName);
+				expect(io.emit).toHaveBeenCalledWith("timerResponse", {
+					secondsRemaining: 10,
+					isPaused: false,
+				});
+			});
+		});
+	});
 });

--- a/helpers/startTimer.test.ts
+++ b/helpers/startTimer.test.ts
@@ -22,13 +22,14 @@ describe("startCountdown", () => {
 				emit: jest.fn(),
 			};
 
-			mockTimer = jest.fn().mockImplementation();
-			timerStore = {
-				[roomName]: {
-					timer: mockTimer,
-				},
-			};
-		});
+      mockTimer = jest.fn().mockImplementation();
+      timerStore = {
+        [roomName]: {
+          timer: mockTimer,
+          isPaused: false,
+        },
+      };
+    });
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -253,27 +254,56 @@ describe("startCountdown", () => {
 						jest.advanceTimersByTime(1000);
 						jest.advanceTimersByTime(1000);
 
-						expect(io.emit).toHaveBeenCalledTimes(1);
-						expect(io.emit).toHaveBeenCalledWith("timerResponse", {
-							secondsRemaining: 10,
-							isPaused: false,
-						});
-					});
-				});
-			});
-			it("should emit a timerResponse event to the room", () => {
-				startCountdown({
-					roomName,
-					durationInSeconds: 10,
-					io: io as any,
-					timerStore: timerStore as any,
-				});
-				expect(io.to).toHaveBeenCalledWith(roomName);
-				expect(io.emit).toHaveBeenCalledWith("timerResponse", {
-					secondsRemaining: 10,
-					isPaused: false,
-				});
-			});
-		});
-	});
+            expect(io.emit).toHaveBeenCalledTimes(1);
+            expect(io.emit).toHaveBeenCalledWith("timerResponse", {
+              secondsRemaining: 10,
+              isPaused: false,
+            });
+          });
+        });
+      });
+
+      describe("when the timer is paused", () => {
+        describe("when the timer is paused before the timer is started", () => {
+          it("should not decrement the secondsRemaining", () => {
+            timerStore[roomName].isPaused = true;
+            startCountdown({
+              roomName,
+              durationInSeconds: 10,
+              io: io as any,
+              timerStore: timerStore as any,
+            });
+            jest.advanceTimersByTime(1000);
+            expect(timerStore[roomName].secondsRemaining).toEqual(10);
+          });
+
+          it("should not clear the timer", () => {
+            timerStore[roomName].isPaused = true;
+            startCountdown({
+              roomName,
+              durationInSeconds: 10,
+              io: io as any,
+              timerStore: timerStore as any,
+            });
+            jest.advanceTimersByTime(1000);
+            // should only be called once when the timer is started
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+          });
+        });
+      });
+      it("should emit a timerResponse event to the room", () => {
+        startCountdown({
+          roomName,
+          durationInSeconds: 10,
+          io: io as any,
+          timerStore: timerStore as any,
+        });
+        expect(io.to).toHaveBeenCalledWith(roomName);
+        expect(io.emit).toHaveBeenCalledWith("timerResponse", {
+          secondsRemaining: 10,
+          isPaused: false,
+        });
+      });
+    });
+  });
 });

--- a/helpers/startTimer.ts
+++ b/helpers/startTimer.ts
@@ -57,11 +57,6 @@ const startCountdown = ({
         timerStore[roomName].secondsRemaining = remainingTime;
       }
     }
-    console.log({
-      roomName,
-      secondsRemaining: remainingTime,
-      isPaused: timerStore[roomName].isPaused,
-    });
   }, 1000);
 
   io.to(roomName).emit("timerResponse", {

--- a/helpers/startTimer.ts
+++ b/helpers/startTimer.ts
@@ -44,23 +44,30 @@ const startCountdown = ({
 	let remainingTime = (timerStore[roomName].secondsRemaining =
 		durationInSeconds);
 
-	// eslint-disable-next-line no-param-reassign
-	timerStore[roomName].timer = setInterval(() => {
-		if (timerStore[roomName].secondsRemaining <= 0) {
-			clearInterval(timerStore[roomName].timer);
-			// eslint-disable-next-line no-param-reassign
-			timerStore[roomName].secondsRemaining = 0;
-		} else {
-			remainingTime--;
-			// eslint-disable-next-line no-param-reassign
-			timerStore[roomName].secondsRemaining = remainingTime;
-		}
-	}, 1000);
+// eslint-disable-next-line no-param-reassign
+  timerStore[roomName].timer = setInterval(() => {
+    if (!timerStore[roomName].isPaused) {
+      if (timerStore[roomName].secondsRemaining <= 0) {
+        clearInterval(timerStore[roomName].timer);
+		// eslint-disable-next-line no-param-reassign
+        timerStore[roomName].secondsRemaining = 0;
+      } else {
+        remainingTime--;
+		// eslint-disable-next-line no-param-reassign
+        timerStore[roomName].secondsRemaining = remainingTime;
+      }
+    }
+    console.log({
+      roomName,
+      secondsRemaining: remainingTime,
+      isPaused: timerStore[roomName].isPaused,
+    });
+  }, 1000);
 
-	io.to(roomName).emit("timerResponse", {
-		secondsRemaining: remainingTime,
-		isPaused: false,
-	});
-};
+  io.to(roomName).emit("timerResponse", {
+    secondsRemaining: remainingTime,
+    isPaused: timerStore[roomName].isPaused,
+  });
+}
 
 export default startCountdown;

--- a/helpers/startTimer.ts
+++ b/helpers/startTimer.ts
@@ -44,25 +44,25 @@ const startCountdown = ({
 	let remainingTime = (timerStore[roomName].secondsRemaining =
 		durationInSeconds);
 
-// eslint-disable-next-line no-param-reassign
-  timerStore[roomName].timer = setInterval(() => {
-    if (!timerStore[roomName].isPaused) {
-      if (timerStore[roomName].secondsRemaining <= 0) {
-        clearInterval(timerStore[roomName].timer);
-		// eslint-disable-next-line no-param-reassign
-        timerStore[roomName].secondsRemaining = 0;
-      } else {
-        remainingTime--;
-		// eslint-disable-next-line no-param-reassign
-        timerStore[roomName].secondsRemaining = remainingTime;
-      }
-    }
-  }, 1000);
+	// eslint-disable-next-line no-param-reassign
+	timerStore[roomName].timer = setInterval(() => {
+		if (!timerStore[roomName].isPaused) {
+			if (timerStore[roomName].secondsRemaining <= 0) {
+				clearInterval(timerStore[roomName].timer);
+				// eslint-disable-next-line no-param-reassign
+				timerStore[roomName].secondsRemaining = 0;
+			} else {
+				remainingTime--;
+				// eslint-disable-next-line no-param-reassign
+				timerStore[roomName].secondsRemaining = remainingTime;
+			}
+		}
+	}, 1000);
 
-  io.to(roomName).emit("timerResponse", {
-    secondsRemaining: remainingTime,
-    isPaused: timerStore[roomName].isPaused,
-  });
-}
+	io.to(roomName).emit("timerResponse", {
+		secondsRemaining: remainingTime,
+		isPaused: timerStore[roomName].isPaused,
+	});
+};
 
 export default startCountdown;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:ci": "npm i && npm run build",
     "dev": "npx tsc && concurrently \"npx tsc --watch\" \"nodemon dist/server.js\"",
     "dev:skip-tests": "npx tsc && concurrently \"npx tsc --watch --project tsconfig.skip-tests.json\" \"nodemon dist/server.js\"",
-    "test": "jest --watchAll --verbose --coverage",
+    "test": "rm -rf dist && jest --watchAll --verbose --coverage",
     "test:ci": "jest --ci --verbose --coverage",
     "build:package": "rm -rf node_modules && rm package-lock.json && npm i",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",

--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,7 @@ import {
 	SocketData,
 	EmitStartCountdownArgs,
 	EmitTimerRequestArgs,
+  EmitTPauseArgs,
 } from "./common/types/socket/types";
 
 const app = express();
@@ -152,30 +153,41 @@ io.on("connection", (socket) => {
 		socket.leave(roomName);
 	});
 
-	// handle requests to start a countdown
-	socket.on(
-		"startCountdown",
-		// eslint-disable-next-line no-shadow
-		({ roomName, durationInSeconds }: EmitStartCountdownArgs) => {
-			console.log({ roomName, durationInSeconds });
-			if (roomName !== "default") {
-				startCountdown({ roomName, durationInSeconds, io, timerStore });
-			}
-		}
-	);
+  // handle requests to start a countdown
+  socket.on(
+    "startCountdown",
+    // eslint-disable-next-line no-shadow
+    ({ roomName, durationInSeconds }: EmitStartCountdownArgs) => {
+      console.log({ roomName, durationInSeconds });
+      if (roomName !== "default") {
+        timerStore[roomName].isPaused = false;
+        startCountdown({ roomName, durationInSeconds, io, timerStore });
+      }
+    }
+  );
 
 	// eslint-disable-next-line no-shadow
 	socket.on("timerRequest", ({ roomName }: EmitTimerRequestArgs) => {
 		timerRequest({ roomName, timerStore, socket });
 	});
 
-	// handle requests to pause a countdown
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	socket.on("pauseCountdown", () => {});
+  // handle requests to pause a countdown
+  socket.on("pauseCountdown", ({ roomName }: EmitTPauseArgs) => {
+    console.log("pauseCountdown", roomName, timerStore[roomName]);
+    if (timerStore[roomName]) {
+      timerStore[roomName].isPaused === true
+        ? (timerStore[roomName].isPaused = false)
+        : (timerStore[roomName].isPaused = true);
+    } 
+    startCountdown({
+      roomName,
+      durationInSeconds: timerStore[roomName].secondsRemaining,
+      io,
+      timerStore,
+    });
+    timerRequest({ roomName, timerStore, socket });
+  });
 
-	// handle requests to unpause a countdown
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	socket.on("unpauseCountdown", () => {});
 });
 
 export { io, httpServer, timerStore };

--- a/server.ts
+++ b/server.ts
@@ -15,7 +15,7 @@ import {
 	SocketData,
 	EmitStartCountdownArgs,
 	EmitTimerRequestArgs,
-  EmitTPauseArgs,
+	EmitTPauseArgs,
 } from "./common/types/socket/types";
 
 const app = express();
@@ -153,40 +153,40 @@ io.on("connection", (socket) => {
 		socket.leave(roomName);
 	});
 
-  // handle requests to start a countdown
-  socket.on(
-    "startCountdown",
-    // eslint-disable-next-line no-shadow
-    ({ roomName, durationInSeconds }: EmitStartCountdownArgs) => {
-      console.log({ roomName, durationInSeconds });
-      if (roomName !== "default") {
-        timerStore[roomName].isPaused = false;
-        startCountdown({ roomName, durationInSeconds, io, timerStore });
-      }
-    }
-  );
+	// handle requests to start a countdown
+	socket.on(
+		"startCountdown",
+		// eslint-disable-next-line no-shadow
+		({ roomName, durationInSeconds }: EmitStartCountdownArgs) => {
+			console.log({ roomName, durationInSeconds });
+			if (roomName !== "default") {
+				timerStore[roomName].isPaused = false;
+				startCountdown({ roomName, durationInSeconds, io, timerStore });
+			}
+		}
+	);
 
 	// eslint-disable-next-line no-shadow
 	socket.on("timerRequest", ({ roomName }: EmitTimerRequestArgs) => {
 		timerRequest({ roomName, timerStore, socket });
 	});
 
-  // handle requests to pause a countdown
-  socket.on("pauseCountdown", ({ roomName }: EmitTPauseArgs) => {
-    console.log("pauseCountdown", roomName, timerStore[roomName]);
-    if (timerStore[roomName]) {
-      timerStore[roomName].isPaused === true
-        ? (timerStore[roomName].isPaused = false)
-        : (timerStore[roomName].isPaused = true);
-    } 
-    startCountdown({
-      roomName,
-      durationInSeconds: timerStore[roomName].secondsRemaining,
-      io,
-      timerStore,
-    });
-    timerRequest({ roomName, timerStore, socket });
-  });
+	// handle requests to pause a countdown
+	socket.on("pauseCountdown", ({ roomName }: EmitTPauseArgs) => {
+		console.log("pauseCountdown", roomName, timerStore[roomName]);
+		if (timerStore[roomName]) {
+			timerStore[roomName].isPaused === true
+				? (timerStore[roomName].isPaused = false)
+				: (timerStore[roomName].isPaused = true);
+		}
+		startCountdown({
+			roomName,
+			durationInSeconds: timerStore[roomName].secondsRemaining,
+			io,
+			timerStore,
+		});
+		timerRequest({ roomName, timerStore, socket });
+	});
 });
 
 export { io, httpServer, timerStore };

--- a/server.ts
+++ b/server.ts
@@ -187,7 +187,6 @@ io.on("connection", (socket) => {
     });
     timerRequest({ roomName, timerStore, socket });
   });
-
 });
 
 export { io, httpServer, timerStore };


### PR DESCRIPTION
## Description
Added frontend logic to the pause/resume functionality.

This PR goes along with https://github.com/CommunityFocus/cf-frontend/pull/31

Closes CommunityFocus/CommunityFocus/issues/17

Workflow:
1. When the user clicks on the pause button, there is a `pauseCountdown` socket event emitted to the server
2. The server listens for this, responds with `timerResponse` to all connected clients, and also sets the ` timerStore[roomname].isPaused` to the boolean value
3. When the client receives the `timerResponse` event from the server, the client will stop the existing timer, start a new timer, and will set `isPaused` to the boolean value