### PR TITLE
Add functionality to reset timer

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 .eslintrc.js
 jest.config.js
+/dist

--- a/common/types/socket/types.ts
+++ b/common/types/socket/types.ts
@@ -5,11 +5,7 @@ export interface EmitStartCountdownArgs {
 	durationInSeconds: number;
 }
 
-export interface EmitTimerRequestArgs {
-	roomName: string;
-}
-
-export interface EmitTPauseArgs {
+export interface EmitWithRoomNameArgs {
 	roomName: string;
 }
 
@@ -28,8 +24,9 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
 	startCountdown: (data: EmitStartCountdownArgs) => void;
 	join: (roomName: string) => void;
-	timerRequest: (data: EmitTimerRequestArgs) => void;
-	pauseCountdown: (data: EmitTPauseArgs) => void;
+	timerRequest: (data: EmitWithRoomNameArgs) => void;
+	pauseCountdown: (data: EmitWithRoomNameArgs) => void;
+	resetCountdown: (data: EmitWithRoomNameArgs) => void;
 }
 
 // io.on

--- a/common/types/types.ts
+++ b/common/types/types.ts
@@ -5,5 +5,6 @@ export interface TimerStore {
 		secondsRemaining: number;
 		isPaused: boolean;
 		destroyTimer?: NodeJS.Timeout;
+		originalDuration: number;
 	};
 }

--- a/controllers/apiController.test.ts
+++ b/controllers/apiController.test.ts
@@ -46,12 +46,14 @@ describe("apiController", () => {
 					timer: undefined,
 					secondsRemaining: 0,
 					isPaused: false,
+					originalDuration: 0,
 				},
 				"second-room-name": {
 					users: [],
 					timer: undefined,
 					secondsRemaining: 0,
 					isPaused: false,
+					originalDuration: 0,
 				},
 			};
 
@@ -83,6 +85,7 @@ describe("apiController", () => {
 					timer: undefined,
 					secondsRemaining: 0,
 					isPaused: false,
+					originalDuration: 0,
 				},
 			};
 			generateSlugMock.mockReturnValue("test");

--- a/server.ts
+++ b/server.ts
@@ -14,8 +14,7 @@ import {
 	ServerToClientEvents,
 	SocketData,
 	EmitStartCountdownArgs,
-	EmitTimerRequestArgs,
-	EmitTPauseArgs,
+	EmitWithRoomNameArgs,
 } from "./common/types/socket/types";
 
 const app = express();
@@ -61,6 +60,7 @@ const io = new Server<
  *    secondsRemaining: number,
  *    isPaused: boolean,
  *    destroyTimer?: setTimeout() // optional: Only set if there are no users in the room at any given time
+ *    originalDuration: number // Original duration of the timer in seconds for resetting the timer
  *    }
  * }
  */
@@ -87,6 +87,7 @@ io.on("connection", (socket) => {
 			timer: undefined,
 			secondsRemaining: 0,
 			isPaused: false,
+			originalDuration: 0,
 		};
 	}
 	// console.log("timerStore", timerStore);
@@ -161,18 +162,19 @@ io.on("connection", (socket) => {
 			console.log({ roomName, durationInSeconds });
 			if (roomName !== "default") {
 				timerStore[roomName].isPaused = false;
+				timerStore[roomName].originalDuration = durationInSeconds;
 				startCountdown({ roomName, durationInSeconds, io, timerStore });
 			}
 		}
 	);
 
 	// eslint-disable-next-line no-shadow
-	socket.on("timerRequest", ({ roomName }: EmitTimerRequestArgs) => {
+	socket.on("timerRequest", ({ roomName }: EmitWithRoomNameArgs) => {
 		timerRequest({ roomName, timerStore, socket });
 	});
 
 	// handle requests to pause a countdown
-	socket.on("pauseCountdown", ({ roomName }: EmitTPauseArgs) => {
+	socket.on("pauseCountdown", ({ roomName }: EmitWithRoomNameArgs) => {
 		console.log("pauseCountdown", roomName, timerStore[roomName]);
 		if (timerStore[roomName]) {
 			timerStore[roomName].isPaused === true
@@ -186,6 +188,19 @@ io.on("connection", (socket) => {
 			timerStore,
 		});
 		timerRequest({ roomName, timerStore, socket });
+	});
+
+	socket.on("resetCountdown", ({ roomName }: EmitWithRoomNameArgs) => {
+		if(roomName !== "default") {
+			timerStore[roomName].isPaused = false;
+			startCountdown({
+				roomName,
+				durationInSeconds: timerStore[roomName].originalDuration,
+				io,
+				timerStore,
+			});
+			timerRequest({ roomName, timerStore, socket });
+		}
 	});
 });
 

--- a/server.ts
+++ b/server.ts
@@ -175,7 +175,6 @@ io.on("connection", (socket) => {
 
 	// handle requests to pause a countdown
 	socket.on("pauseCountdown", ({ roomName }: EmitWithRoomNameArgs) => {
-		console.log("pauseCountdown", roomName, timerStore[roomName]);
 		if (timerStore[roomName]) {
 			timerStore[roomName].isPaused === true
 				? (timerStore[roomName].isPaused = false)

--- a/server.ts
+++ b/server.ts
@@ -174,8 +174,10 @@ io.on("connection", (socket) => {
 	});
 
 	// handle requests to pause a countdown
+	// eslint-disable-next-line no-shadow
 	socket.on("pauseCountdown", ({ roomName }: EmitWithRoomNameArgs) => {
 		if (timerStore[roomName]) {
+			// eslint-disable-next-line no-unused-expressions
 			timerStore[roomName].isPaused === true
 				? (timerStore[roomName].isPaused = false)
 				: (timerStore[roomName].isPaused = true);
@@ -189,8 +191,9 @@ io.on("connection", (socket) => {
 		timerRequest({ roomName, timerStore, socket });
 	});
 
+	// eslint-disable-next-line no-shadow
 	socket.on("resetCountdown", ({ roomName }: EmitWithRoomNameArgs) => {
-		if(roomName !== "default") {
+		if (roomName !== "default") {
 			timerStore[roomName].isPaused = false;
 			startCountdown({
 				roomName,


### PR DESCRIPTION
## Description
Add reset timer functionality. The client will emit a `resetCountdown` event which the server will use to restart the countdown from the timerStore object.

To be closed together with: https://github.com/CommunityFocus/cf-frontend/pull/37
Closes CommunityFocus/CommunityFocus/issues/16