### PR TITLE
Feat/user bubbles

### DIFF
--- a/common/types/socket/types.ts
+++ b/common/types/socket/types.ts
@@ -16,7 +16,14 @@ export interface EmitTimerResponseArgs {
 
 // all emit events
 export interface ServerToClientEvents {
-	usersInRoom: (numUsers: number) => void;
+	usersInRoom: ({
+		numUsers,
+		userList,
+	}: {
+		numUsers: number;
+		userList: string[];
+	}) => void;
+
 	timerResponse: (data: EmitTimerResponseArgs) => void;
 }
 

--- a/common/types/socket/types.ts
+++ b/common/types/socket/types.ts
@@ -14,15 +14,14 @@ export interface EmitTimerResponseArgs {
 	isPaused: boolean;
 }
 
+export interface EmitUsersInRoomArgs {
+	numUsers: number;
+	userList: string[];
+}
+
 // all emit events
 export interface ServerToClientEvents {
-	usersInRoom: ({
-		numUsers,
-		userList,
-	}: {
-		numUsers: number;
-		userList: string[];
-	}) => void;
+	usersInRoom: ({ numUsers, userList }: EmitUsersInRoomArgs) => void;
 	globalUsers: (data: { globalUsersCount: number }) => void;
 	timerResponse: (data: EmitTimerResponseArgs) => void;
 }

--- a/server.ts
+++ b/server.ts
@@ -108,10 +108,10 @@ io.on("connection", (socket) => {
 			timerStore[roomName].users.push(socket.id);
 
 			// emit the updated number of users in the room
-			io.to(roomName).emit(
-				"usersInRoom",
-				timerStore[roomName].users.length
-			);
+			io.to(roomName).emit("usersInRoom", {
+				numUsers: timerStore[roomName].users.length,
+				userList: timerStore[roomName].users,
+			});
 
 			console.log(`User ${socket.id} joined room ${roomName}`);
 		}
@@ -130,10 +130,10 @@ io.on("connection", (socket) => {
 			console.log(`User ${socket.id} disconnected from room ${roomName}`);
 
 			// emit the updated number of users in the room
-			io.to(roomName).emit(
-				"usersInRoom",
-				timerStore[roomName].users.length
-			);
+			io.to(roomName).emit("usersInRoom", {
+				numUsers: timerStore[roomName].users.length,
+				userList: timerStore[roomName].users,
+			});
 
 			if (timerStore[roomName].users.length === 0) {
 				// if there are no users left in the room, clear the timer and delete the room after a delay


### PR DESCRIPTION
## Description
Add user bubbles to show the list of users in the current room

To be closed together with: https://github.com/CommunityFocus/cf-frontend/pull/44

Functionality:
1. When user joins, the user bubble gets added to all clients in that room
2. When user joins, the joined user gets a list of all connected clients
3. When user leaves, the user bubbles on all connected clients get updated to remove that user
4. if there are more than 6 clients, the 7th bubble is a concatenation that says +1 or +2 as required
5. Add tooltip to show the name of the user


Closes CommunityFocus/CommunityFocus/issues/61

1 user:
<img width="275" alt="image" src="https://github.com/CommunityFocus/cf-backend/assets/45009203/57e00386-46bc-4a9f-a223-4a4279bcb5e8">

6+ users:
<img width="525" alt="image" src="https://github.com/CommunityFocus/cf-backend/assets/45009203/586c4bc7-7729-48aa-8535-d1b8919e2464">

Tooltip:
<img width="589" alt="image" src="https://github.com/CommunityFocus/cf-frontend/assets/45009203/08e5880a-dfd7-4bb8-8b7a-492c90f413a2">